### PR TITLE
Updating tools to work in 2016

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source 'http://ruby.taobao.org'
+source "http://rubygems.org"
 
 gem 'sass',    '>= 3.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://ruby.taobao.org/
+  remote: http://rubygems.org/
   specs:
     sass (3.4.3)
 
@@ -8,3 +8,6 @@ PLATFORMS
 
 DEPENDENCIES
   sass (>= 3.4.0)
+
+BUNDLED WITH
+   1.12.5

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   },
   "devDependencies": {
     "grunt": "0.x",
-    "grunt-contrib-watch": "0.x",
     "grunt-contrib-coffee": "0.x",
+    "grunt-contrib-jasmine": "^1.0.3",
     "grunt-contrib-sass": "0.x",
-    "grunt-contrib-jasmine": "0.x",
+    "grunt-contrib-watch": "0.x",
     "grunt-umd": "2.x"
   }
 }


### PR DESCRIPTION
- Gemfile sources rubygems now. This isn't probably a 2016, but whatever the issue, reverting to rubygems helped
- Upgrading grunt-contrib-jasmine to pass tests locally