### PR TITLE
Fixing mentions in Mobile (v4.0.0-alpha.1)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-simditor-mention",
-  "version": "4.0.0-alpha",
+  "version": "4.0.0-alpha.1",
   "homepage": "https://github.com/townsquared/simditor-mention",
   "authors": [
     "CJ Ting <fatelovely1128@gmail.com",

--- a/lib/simditor-mention.js
+++ b/lib/simditor-mention.js
@@ -138,6 +138,11 @@ SimditorMention = (function(superClass) {
         return e.result;
       };
     })(this));
+    this.editor.body.bind('mousedown touchend', (function(_this) {
+      return function() {
+        return _this.editor.focus();
+      };
+    })(this));
     this.editor.on('keydown', (function(_this) {
       return function(e) {
         if (e.which !== 229) {
@@ -278,7 +283,7 @@ SimditorMention = (function(superClass) {
     this.popoverEl.on('mouseenter', '.item', function(e) {
       return $(this).addClass('selected').siblings('.item').removeClass('selected');
     });
-    this.popoverEl.on('mousedown', '.item', (function(_this) {
+    this.popoverEl.on('mousedown touchend', '.item', (function(_this) {
       return function(e) {
         _this.selectItem();
         return false;
@@ -346,7 +351,7 @@ SimditorMention = (function(superClass) {
     if (this.popoverEl != null) {
       $itemEls = this.popoverEl.find('.item');
     }
-    if (this._isXHREnabled()) {
+    if (this._isXHREnabled() && val.length) {
       if (this.popoverEl != null) {
         this.popoverEl.hide();
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-simditor-mention",
-  "version": "4.0.0-alpha",
+  "version": "4.0.0-alpha.1",
   "description": "A Mention plugin for Simditor",
   "main": "lib/simditor-mention.js",
   "repository": {

--- a/src/simditor-mention.coffee
+++ b/src/simditor-mention.coffee
@@ -95,6 +95,8 @@ class SimditorMention extends SimpleModule
       return false if @editor.body.find('span.simditor-mention').length > 0
       e.result
 
+    @editor.body.bind 'mousedown touchend', ()=>
+      @editor.focus()
 
     @editor.on 'keydown', (e)=>
       return unless e.which is 229
@@ -226,7 +228,7 @@ class SimditorMention extends SimpleModule
       $(@).addClass 'selected'
         .siblings '.item'
         .removeClass 'selected'
-    @popoverEl.on 'mousedown','.item', (e)=>
+    @popoverEl.on 'mousedown touchend','.item', (e)=>
       @selectItem()
       false
 
@@ -290,7 +292,7 @@ class SimditorMention extends SimpleModule
     # Exists when items are static, or fetched dynamically 2nd or more times
     $itemEls = @popoverEl.find '.item' if @popoverEl?
 
-    if @_isXHREnabled()
+    if @_isXHREnabled() and val.length
       # Only hide items are fetched 2nd or more times
       @popoverEl.hide() if @popoverEl?
       return @getItems(val).then () =>


### PR DESCRIPTION
- iOS browsers use the `touchend` event instead of `mousedown`
- The editor should bring the focus back on itself on click
- The editor should only make XHR requests if there is a value